### PR TITLE
Add standard GitHub repository files

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,129 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+*   Demonstrating empathy and kindness toward other people
+*   Being respectful of differing opinions, viewpoints, and experiences
+*   Giving and gracefully accepting constructive feedback
+*   Accepting responsibility and apologizing to those affected by our mistakes,
+    and learning from the experience
+*   Focusing on what is best not just for us as individuals, but for the
+    overall community
+
+Examples of unacceptable behavior include:
+
+*   The use of sexualized language or imagery, and sexual attention or
+    advances of any kind
+*   Trolling, insulting or derogatory comments, and personal or political attacks
+*   Public or private harassment
+*   Publishing others' private information, such as a physical or email
+    address, without their explicit permission
+*   Other conduct which could reasonably be considered inappropriate in a
+    professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing to [Project Name]
+
+First off, thank you for considering contributing to [Project Name]! It's people like you that make [Project Name] such a great tool.
+
+Following these guidelines helps to communicate that you respect the time of the developers managing and developing this open source project. In return, they should reciprocate that respect in addressing your issue, assessing changes, and helping you finalize your pull requests.
+
+## Getting Started
+
+Contributions are made to this repo via Issues and Pull Requests (PRs).
+- **Issues** are used to track bugs, request features, or discuss potential changes.
+- **Pull Requests** are the way to contribute code or documentation changes.
+
+Before you start working on a contribution, please check the existing issues and PRs to see if someone else is already working on something similar. If not, feel free to open a new issue to discuss your idea.
+
+## How to Contribute
+
+### Reporting Bugs
+
+If you find a bug, please open an issue using the "Bug Report" template. Provide as much detail as possible, including:
+- Steps to reproduce the bug.
+- What you expected to happen.
+- What actually happened.
+- Your environment (OS, browser, versions, etc.).
+- Any relevant logs or screenshots.
+
+### Suggesting Enhancements
+
+If you have an idea for a new feature or an improvement to an existing one, please open an issue using the "Feature Request" template. Provide a clear and detailed explanation of your suggestion, including:
+- The problem your feature would solve.
+- Your proposed solution.
+- Any alternative solutions you've considered.
+
+### Your First Code Contribution
+
+Unsure where to begin contributing to [Project Name]? You can start by looking through these `good first issue` and `help wanted` issues:
+- [Good first issues](https://github.com/[OWNER]/[REPOSITORY]/labels/good%20first%20issue) - issues which should only require a few lines of code, and a test or two.
+- [Help wanted issues](https://github.com/[OWNER]/[REPOSITORY]/labels/help%20wanted) - issues which should be a bit more involved than `good first issue` issues.
+
+### Making Changes
+
+1.  **Fork the repository** to your own GitHub account.
+2.  **Clone your fork** locally: `git clone https://github.com/your-username/[REPOSITORY].git`
+3.  **Create a new branch** for your changes: `git checkout -b your-feature-branch-name`
+4.  **Make your changes**.
+    *   Follow the coding style of the project (e.g., run linters/formatters if provided).
+    *   Write clear, concise commit messages.
+    *   Add tests for your changes.
+5.  **Push your changes** to your fork: `git push origin your-feature-branch-name`
+6.  **Open a Pull Request** to the `main` branch (or the relevant development branch) of the original repository.
+    *   Fill out the PR template with details about your changes.
+    *   Link any relevant issues.
+
+## Pull Request Process
+
+1.  The maintainers will review your PR. They may ask for changes or provide feedback.
+2.  Make any necessary updates to your PR based on the feedback.
+3.  Once your PR is approved and passes all checks, a maintainer will merge it.
+
+Please be patient during the review process. We will do our best to review your PR as soon as possible.
+
+## Code of Conduct
+
+This project and everyone participating in it is governed by the [Project Name Code of Conduct](./CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [CONTACT METHOD].
+
+## Questions?
+
+If you have any questions, feel free to reach out by opening an issue or contacting the maintainers at [CONTACT METHOD].
+
+Thank you for contributing!
+
+---
+**Note to project maintainers:**
+*   Replace `[Project Name]` with the actual name of your project.
+*   Replace `[OWNER]/[REPOSITORY]` with your GitHub organization/username and repository name in the links.
+*   Replace `[CONTACT METHOD]` with the appropriate contact information for reporting Code of Conduct violations or asking questions. This could be an email address or a link to a discussion forum.
+*   Review and customize the "Your First Code Contribution" section to point to relevant labels or resources for new contributors.
+*   Ensure the `CODE_OF_CONDUCT.md` path is correct.
+*   You might want to add sections on:
+    *   Setting up the development environment.
+    *   Coding standards or style guides.
+    *   How to run tests.
+    *   Release process (if contributors need to know).
+    *   Community and communication channels (Slack, Discord, mailing list, etc.).

--- a/.github/GOVERNANCE.md
+++ b/.github/GOVERNANCE.md
@@ -1,0 +1,19 @@
+# Governance Model
+
+This project adheres to a simple governance model.
+
+## Roles
+
+*   **Maintainers:** Responsible for the overall health and direction of the project. They have write access to the repository and can merge pull requests.
+*   **Contributors:** Anyone who contributes code, documentation, or other improvements to the project.
+
+## Decision Making
+
+*   Most decisions are made through consensus among the maintainers.
+*   Significant changes or new features are discussed via GitHub Issues or Pull Requests.
+
+## Becoming a Maintainer
+
+*   Contributors who have shown a sustained commitment to the project and a good understanding of its goals may be invited to become maintainers.
+
+This is a basic model and may evolve as the project grows.

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,85 @@
+name: Bug Report
+description: File a bug report
+title: "[Bug]: "
+labels: ["bug", "triage"]
+assignees:
+  - octocat # Optional: replace with default assignee username
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps to reproduce
+      description: "How can we reproduce the issue? Please provide a step-by-step guide."
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+  - type: dropdown
+    id: version
+    attributes:
+      label: Version
+      description: What version of our software are you running?
+      options:
+        - 1.0.2 (Default)
+        - 1.0.1
+        - 1.0.0
+        - Other (please specify in 'Environment' section)
+      default: 0
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: |
+        examples:
+          - **OS**: [e.g. iOS]
+          - **Browser (if applicable)**: [e.g. chrome, safari]
+          - **Version (if applicable)**: [e.g. 22]
+          - **Node version (if applicable)**: [e.g. 16.0.0]
+          - **Package manager & version (if applicable)**: [e.g. npm 8.0.0]
+      value: |
+        - OS:
+        - Browser (if applicable):
+        - Version (if applicable):
+      render: markdown
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature Request
+description: Suggest an idea for this project
+title: "[Feature]: "
+labels: ["enhancement", "feature"]
+assignees:
+  - octocat # Optional: replace with default assignee username
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this feature request!
+  - type: textarea
+    id: problem-description
+    attributes:
+      label: Is your feature request related to a problem? Please describe.
+      description: A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+      placeholder: Tell us about the problem you're experiencing.
+    validations:
+      required: true
+  - type: textarea
+    id: solution-description
+    attributes:
+      label: Describe the solution you'd like
+      description: A clear and concise description of what you want to happen.
+      placeholder: What would be the ideal solution?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives-considered
+    attributes:
+      label: Describe alternatives you've considered
+      description: A clear and concise description of any alternative solutions or features you've considered.
+      placeholder: What other ways could this problem be solved?
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.
+      placeholder: Any extra details?
+    validations:
+      required: false
+  - type: checkboxes
+    id: terms
+    attributes:
+      label: Code of Conduct
+      description: By submitting this issue, you agree to follow our [Code of Conduct](../CODE_OF_CONDUCT.md)
+      options:
+        - label: I agree to follow this project's Code of Conduct
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,59 @@
+<!--
+Thank you for contributing! Please fill out this template so that we can review your PR more effectively.
+-->
+
+## What does this PR do?
+
+<!--
+Please include a summary of the change and which issue is fixed.
+Please also include relevant motivation and context.
+List any dependencies that are required for this change.
+
+Closes #(issue)
+-->
+
+## Type of change
+
+<!--
+Please delete options that are not relevant.
+-->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Chore (refactoring, adding tests, or other non-functional changes)
+
+## How should this be tested?
+
+<!--
+Please describe the tests that you ran to verify your changes.
+Provide instructions so we can reproduce.
+Please also list any relevant details for your test configuration.
+
+- Test A
+- Test B
+-->
+
+## Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules
+
+## Screenshots (if applicable)
+
+<!--
+If your PR includes visual changes, please include screenshots or GIFs.
+-->
+
+## Additional context
+
+<!--
+Add any other context about the problem here.
+-->

--- a/.github/README.md
+++ b/.github/README.md
@@ -1,0 +1,2 @@
+# This is a placeholder README file for the .github directory.
+# It can be updated later with more specific information if needed.

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,52 @@
+# Security Policy
+
+## Supported Versions
+
+Use this section to tell people about which versions of your project are
+currently being supported with security updates.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 5.1.x   | :white_check_mark: |
+| 5.0.x   | :x:                |
+| 4.0.x   | :white_check_mark: |
+| < 4.0   | :x:                |
+
+## Reporting a Vulnerability
+
+We take security vulnerabilities seriously. If you discover a security vulnerability, please report it to us as soon as possible.
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please email us at [INSERT SECURITY EMAIL ADDRESS HERE].
+
+You should receive a response within 48 hours. If for some reason you do not, please follow up via email to ensure we received your original message.
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+*   Type of issue (e.g., buffer overflow, SQL injection, cross-site scripting, etc.)
+*   Full paths of source file(s) related to the manifestation of the vulnerability
+*   The location of the affected source code (tag/branch/commit or direct URL)
+*   Any special configuration required to reproduce the issue
+*   Step-by-step instructions to reproduce the issue
+*   Proof-of-concept or exploit code (if possible)
+*   Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+We prefer all communications to be in English.
+
+## Security Advisories
+
+We will issue security advisories for any confirmed vulnerabilities. These will be published via GitHub Security Advisories.
+
+## Our Commitment
+
+*   We will investigate all reported vulnerabilities promptly.
+*   We will work with you to understand and validate the vulnerability.
+*   We will take appropriate action to address the vulnerability.
+*   We will publicly disclose the vulnerability once a fix is available, unless there is a compelling reason not to.
+
+We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+This security policy is a living document and may be updated over time.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,43 @@
+# This is a CITATION.cff file.
+# You can use it to provide citation information for your software.
+# See https://citation-file-format.github.io/ for more information.
+
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: "Your Family Name"
+    given-names: "Your Given Name"
+    orcid: "https://orcid.org/YOUR-ORCID-ID" # Optional
+  # Add more authors if needed
+title: "Your Project Title"
+version: 0.1.0 # Replace with your project's version
+date-released: YYYY-MM-DD # Replace with the release date
+# Below are optional fields. Uncomment and fill them if applicable.
+# abstract: "A short description of your software."
+# keywords:
+#   - keyword1
+#   - keyword2
+# license: MIT # Replace with your project's license
+# repository-code: "https://github.com/your-username/your-repository"
+# url: "https://your-project-website.com" # If you have a project website
+# doi: "10.5281/zenodo.XXXXXXX" # If you have a DOI for your software
+# identifiers:
+#   - type: doi
+#     value: 10.5281/zenodo.XXXXXXX
+#     description: The DOI for the software version.
+#   - type: url
+#     value: "https://github.com/your-username/your-repository/tree/v0.1.0"
+#     description: The URL of the specific software version.
+# preferred-citation:
+#   type: article # or book, conference-paper, software, report, thesis, etc.
+#   authors:
+#     - family-names: "Your Family Name"
+#       given-names: "Your Given Name"
+#   title: "Title of the publication that describes this software"
+#   journal: "Journal Name" # if type is article
+#   volume: 1
+#   issue: 1
+#   year: YYYY
+#   pages: "1-10"
+#   doi: "DOI of the publication" # if available
+#   url: "URL of the publication" # if available


### PR DESCRIPTION
This commit adds a .github/ directory and populates it with common GitHub preset files to help manage the project, including:

- GOVERNANCE.md: Basic project governance model.
- CITATION.cff: Placeholder for project citation information.
- CODE_OF_CONDUCT.md: Contributor Covenant based Code of Conduct.
- SECURITY.md: Basic security policy and vulnerability reporting guidelines.
- PULL_REQUEST_TEMPLATE.md: Template for pull requests.
- ISSUE_TEMPLATE/bug_report.yml: Template for bug reports.
- ISSUE_TEMPLATE/feature_request.yml: Template for feature requests.
- CONTRIBUTING.md: Guidelines for contributing to the project.

These files provide a starting point and will require customization by the project maintainers with specific project details.